### PR TITLE
Fix issue with total values on linked partitions

### DIFF
--- a/src/LinkablePartition.php
+++ b/src/LinkablePartition.php
@@ -14,11 +14,12 @@ trait LinkablePartition
      */
     public function result(array $value)
     {
-        $linkablePartitionResult = new LinkablePartitionResult($value);
+        $linkablePartitionResult = new LinkablePartitionResult(collect($value)->map(function ($number) {
+            return round($number, $this->roundingPrecision, $this->roundingMode);
+        })->toArray());
         if (!empty($this->url)) {
             $linkablePartitionResult->url($this->url);
         }
         return $linkablePartitionResult;
     }
 }
-


### PR DESCRIPTION
The 'total' value would not calculate correctly when linking partition metrics, the 'result' function has been updated to match how it's calculated in the latest version of nova.